### PR TITLE
feat: Add Redis token storage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,9 @@ require (
 )
 
 require (
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/go-redis/redis/v8 v8.11.5 // indirect
 	github.com/gookit/color v1.5.4 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,11 @@
+github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
+github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/go-redis/redis/v8 v8.11.5 h1:AcZZR7igkdvfVmQTPnu9WE37LRrO/YrBH5zWyjDC0oI=
+github.com/go-redis/redis/v8 v8.11.5/go.mod h1:gREzHqY1hg6oD9ngVRbLStwAWKhA0FEgq8Jd4h5lpwo=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/gookit/color v1.5.4 h1:FZmqs7XOyGgCAxmWyPslpiok1k05wmY3SJTytgvYFs0=

--- a/redis/token_storage.go
+++ b/redis/token_storage.go
@@ -1,0 +1,68 @@
+package redis
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/go-redis/redis/v8"
+	"github.com/marvell/strava-go"
+)
+
+// TokenStorage implements the strava.TokenStorage interface using Redis.
+type TokenStorage struct {
+	client *redis.Client
+	prefix string // e.g., "strava:token:"
+}
+
+var _ strava.TokenStorage = (*TokenStorage)(nil)
+
+// NewTokenStorage creates a new Redis TokenStorage.
+func NewTokenStorage(client *redis.Client, keyPrefix string) *TokenStorage {
+	if keyPrefix == "" {
+		keyPrefix = "strava:token:"
+	}
+	return &TokenStorage{
+		client: client,
+		prefix: keyPrefix,
+	}
+}
+
+func (ts *TokenStorage) key(athleteID uint) string {
+	return fmt.Sprintf("%s%d", ts.prefix, athleteID)
+}
+
+// Get retrieves a token from Redis.
+func (ts *TokenStorage) Get(ctx context.Context, athleteID uint) (*strava.Token, error) {
+	key := ts.key(athleteID)
+	val, err := ts.client.Get(ctx, key).Result()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return nil, strava.ErrTokenNotFound
+		}
+		return nil, fmt.Errorf("redis get token for athlete %d (key %s): %w", athleteID, key, err)
+	}
+
+	var token strava.Token
+	if err := json.Unmarshal([]byte(val), &token); err != nil {
+		return nil, fmt.Errorf("redis unmarshal token for athlete %d (key %s): %w", athleteID, key, err)
+	}
+
+	return &token, nil
+}
+
+// Save stores a token in Redis.
+func (ts *TokenStorage) Save(ctx context.Context, token *strava.Token) error {
+	key := ts.key(token.AthleteID)
+	val, err := json.Marshal(token)
+	if err != nil {
+		return fmt.Errorf("redis marshal token for athlete %d (key %s): %w", token.AthleteID, key, err)
+	}
+
+	if err := ts.client.Set(ctx, key, val, 0).Err(); err != nil { // 0 means no expiration
+		return fmt.Errorf("redis set token for athlete %d (key %s): %w", token.AthleteID, key, err)
+	}
+
+	return nil
+}

--- a/redis/token_storage_test.go
+++ b/redis/token_storage_test.go
@@ -14,8 +14,10 @@ import (
 )
 
 var testRedisClient *redis.Client
+var redisAvailable bool // NEW: Global variable to track Redis availability
 
 func TestMain(m *testing.M) {
+	redisAvailable = true // Initialize redisAvailable
 	// Connection options for Redis. Using an environment variable for the address
 	// allows flexibility for different test environments (e.g., CI vs local).
 	redisAddr := os.Getenv("STRAVA_TEST_REDIS_ADDR")
@@ -31,10 +33,11 @@ func TestMain(m *testing.M) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := testRedisClient.Ping(ctx).Err(); err != nil {
-		fmt.Printf("Could not connect to Redis at %s: %v\n", redisAddr, err)
-		fmt.Println("Skipping Redis integration tests. Ensure Redis is running and accessible.")
-		// os.Exit(1) // Or skip tests if Redis is essential
-		return // Exit TestMain without running tests if Redis is not available
+		redisAvailable = false
+		fmt.Printf("Could not connect to Redis at %s: %v. Redis integration tests will be skipped.\n", redisAddr, err)
+		// Do not return or exit; allow m.Run() for other tests
+	} else {
+		fmt.Printf("Successfully connected to Redis at %s for testing.\n", redisAddr)
 	}
 
 	// Run tests
@@ -43,13 +46,22 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
+// NEW: func checkRedis(t *testing.T)
+func checkRedis(t *testing.T) {
+	if !redisAvailable {
+		t.Skipf("Skipping Redis integration test: Redis not available at %s", testRedisClient.Options().Addr)
+	}
+}
+
 func flushRedis(ctx context.Context, t *testing.T) {
+	checkRedis(t) // NEW: Call checkRedis(t) here.
 	if err := testRedisClient.FlushDB(ctx).Err(); err != nil {
 		t.Fatalf("Failed to flush Redis: %v", err)
 	}
 }
 
 func TestNewTokenStorage(t *testing.T) {
+	checkRedis(t) // NEW: Call checkRedis(t) here.
 	tsDefault := NewTokenStorage(testRedisClient, "")
 	if tsDefault.prefix != "strava:token:" {
 		t.Errorf("Expected default prefix 'strava:token:', got '%s'", tsDefault.prefix)
@@ -63,6 +75,7 @@ func TestNewTokenStorage(t *testing.T) {
 }
 
 func TestTokenStorage_SaveAndGet(t *testing.T) {
+	checkRedis(t) // NEW: Call checkRedis(t) here.
 	ctx := context.Background()
 	flushRedis(ctx, t)
 
@@ -85,11 +98,13 @@ func TestTokenStorage_SaveAndGet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Save() error = %v, wantErr nil", err)
 	}
+	t.Logf("Token for athlete %d saved successfully.", athleteID) // OPTIONAL: Use t.Logf
 
 	retrievedToken, err := ts.Get(ctx, athleteID)
 	if err != nil {
 		t.Fatalf("Get() error = %v, wantErr nil", err)
 	}
+	t.Logf("Token for athlete %d retrieved successfully.", athleteID) // OPTIONAL: Use t.Logf
 
 	if retrievedToken.AccessToken != token.AccessToken {
 		t.Errorf("Retrieved AccessToken = %s, want %s", retrievedToken.AccessToken, token.AccessToken)
@@ -110,6 +125,7 @@ func TestTokenStorage_SaveAndGet(t *testing.T) {
 }
 
 func TestTokenStorage_Get_NotFound(t *testing.T) {
+	checkRedis(t) // NEW: Call checkRedis(t) here.
 	ctx := context.Background()
 	flushRedis(ctx, t)
 
@@ -123,6 +139,7 @@ func TestTokenStorage_Get_NotFound(t *testing.T) {
 }
 
 func TestTokenStorage_Save_Overwrite(t *testing.T) {
+	checkRedis(t) // NEW: Call checkRedis(t) here.
 	ctx := context.Background()
 	flushRedis(ctx, t)
 

--- a/redis/token_storage_test.go
+++ b/redis/token_storage_test.go
@@ -1,0 +1,162 @@
+package redis
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+	"github.com/marvell/strava-go"
+	"golang.org/x/oauth2"
+)
+
+var testRedisClient *redis.Client
+
+func TestMain(m *testing.M) {
+	// Connection options for Redis. Using an environment variable for the address
+	// allows flexibility for different test environments (e.g., CI vs local).
+	redisAddr := os.Getenv("STRAVA_TEST_REDIS_ADDR")
+	if redisAddr == "" {
+		redisAddr = "localhost:6379" // Default address
+	}
+
+	testRedisClient = redis.NewClient(&redis.Options{
+		Addr: redisAddr,
+	})
+
+	// Ping Redis to ensure connection before running tests
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := testRedisClient.Ping(ctx).Err(); err != nil {
+		fmt.Printf("Could not connect to Redis at %s: %v\n", redisAddr, err)
+		fmt.Println("Skipping Redis integration tests. Ensure Redis is running and accessible.")
+		// os.Exit(1) // Or skip tests if Redis is essential
+		return // Exit TestMain without running tests if Redis is not available
+	}
+
+	// Run tests
+	code := m.Run()
+
+	os.Exit(code)
+}
+
+func flushRedis(ctx context.Context, t *testing.T) {
+	if err := testRedisClient.FlushDB(ctx).Err(); err != nil {
+		t.Fatalf("Failed to flush Redis: %v", err)
+	}
+}
+
+func TestNewTokenStorage(t *testing.T) {
+	tsDefault := NewTokenStorage(testRedisClient, "")
+	if tsDefault.prefix != "strava:token:" {
+		t.Errorf("Expected default prefix 'strava:token:', got '%s'", tsDefault.prefix)
+	}
+
+	customPrefix := "mycustom:prefix:"
+	tsCustom := NewTokenStorage(testRedisClient, customPrefix)
+	if tsCustom.prefix != customPrefix {
+		t.Errorf("Expected custom prefix '%s', got '%s'", customPrefix, tsCustom.prefix)
+	}
+}
+
+func TestTokenStorage_SaveAndGet(t *testing.T) {
+	ctx := context.Background()
+	flushRedis(ctx, t)
+
+	ts := NewTokenStorage(testRedisClient, "test:strava:token:")
+	athleteID := uint(12345)
+	expiry := time.Now().Add(1 * time.Hour).Round(time.Second) // Round for consistent comparison
+
+	token := &strava.Token{
+		Token: &oauth2.Token{
+			AccessToken:  "test_access_token",
+			RefreshToken: "test_refresh_token",
+			Expiry:       expiry,
+			TokenType:    "Bearer",
+		},
+		AthleteID: athleteID,
+		Scope:     "read,activity:read_all",
+	}
+
+	err := ts.Save(ctx, token)
+	if err != nil {
+		t.Fatalf("Save() error = %v, wantErr nil", err)
+	}
+
+	retrievedToken, err := ts.Get(ctx, athleteID)
+	if err != nil {
+		t.Fatalf("Get() error = %v, wantErr nil", err)
+	}
+
+	if retrievedToken.AccessToken != token.AccessToken {
+		t.Errorf("Retrieved AccessToken = %s, want %s", retrievedToken.AccessToken, token.AccessToken)
+	}
+	if retrievedToken.RefreshToken != token.RefreshToken {
+		t.Errorf("Retrieved RefreshToken = %s, want %s", retrievedToken.RefreshToken, token.RefreshToken)
+	}
+	// Compare time with tolerance or after rounding due to potential precision differences in storage/retrieval
+	if !retrievedToken.Expiry.Equal(token.Expiry) {
+		t.Errorf("Retrieved Expiry = %v, want %v", retrievedToken.Expiry, token.Expiry)
+	}
+	if retrievedToken.AthleteID != token.AthleteID {
+		t.Errorf("Retrieved AthleteID = %d, want %d", retrievedToken.AthleteID, token.AthleteID)
+	}
+	if retrievedToken.Scope != token.Scope {
+		t.Errorf("Retrieved Scope = %s, want %s", retrievedToken.Scope, token.Scope)
+	}
+}
+
+func TestTokenStorage_Get_NotFound(t *testing.T) {
+	ctx := context.Background()
+	flushRedis(ctx, t)
+
+	ts := NewTokenStorage(testRedisClient, "test:strava:token:")
+	athleteID := uint(67890)
+
+	_, err := ts.Get(ctx, athleteID)
+	if !errors.Is(err, strava.ErrTokenNotFound) {
+		t.Fatalf("Get() error = %v, want %v", err, strava.ErrTokenNotFound)
+	}
+}
+
+func TestTokenStorage_Save_Overwrite(t *testing.T) {
+	ctx := context.Background()
+	flushRedis(ctx, t)
+
+	ts := NewTokenStorage(testRedisClient, "test:strava:token:")
+	athleteID := uint(11223)
+	initialToken := &strava.Token{
+		Token: &oauth2.Token{
+			AccessToken: "initial_access_token",
+		},
+		AthleteID: athleteID,
+	}
+	updatedToken := &strava.Token{
+		Token: &oauth2.Token{
+			AccessToken: "updated_access_token",
+		},
+		AthleteID: athleteID,
+	}
+
+	// Save initial token
+	if err := ts.Save(ctx, initialToken); err != nil {
+		t.Fatalf("Save() initial token error = %v", err)
+	}
+
+	// Save updated token for the same athlete
+	if err := ts.Save(ctx, updatedToken); err != nil {
+		t.Fatalf("Save() updated token error = %v", err)
+	}
+
+	retrievedToken, err := ts.Get(ctx, athleteID)
+	if err != nil {
+		t.Fatalf("Get() after overwrite error = %v", err)
+	}
+
+	if retrievedToken.AccessToken != updatedToken.AccessToken {
+		t.Errorf("Retrieved AccessToken = %s, want %s (updated)", retrievedToken.AccessToken, updatedToken.AccessToken)
+	}
+}


### PR DESCRIPTION
Implements a new token storage solution using Redis. This satisfies the `TokenStorage` interface defined in `client.go`.

The implementation includes:
- A `redis.TokenStorage` struct that uses a `go-redis/redis` client.
- `Get` and `Save` methods for token operations.
- Configurable Redis key prefix (defaults to "strava:token:").
- Unit tests for the Redis token storage, requiring a running Redis instance for testing.

This provides a persistent and scalable alternative to the in-memory token storage.